### PR TITLE
AI Summer Camp appears in all links

### DIFF
--- a/docs/Joining.html
+++ b/docs/Joining.html
@@ -160,7 +160,7 @@ body{
               <li><a href="tutorials.html">Tutorials</a></li>
               <li><a href="Special.html">Special Issues</a></li>
               <li><a href="Atiisc.html">At AIISC</a></li>
-             <li><a href="https://aiisc.ai/safari/" target="_blank">AI Safari</a></li>
+             <li><a href="./aicamp24/base.html" target="_blank">AI Summer Camp</a></li>
               <li><a href="focus.html">Focus Group</a></li>
           
 

--- a/docs/Special.html
+++ b/docs/Special.html
@@ -180,7 +180,7 @@ body{
               <li><a href="tutorials.html">Tutorials</a></li>
               <li><a class="active" href="Special.html">Special Issues</a></li>
               <li><a href="Atiisc.html">At AIISC</a></li>
-             <li><a href="https://aiisc.ai/safari/" target="_blank">AI Safari</a></li>
+             <li><a href="./aicamp24/base.html" target="_blank">AI Summer Camp</a></li>
               <li><a href="focus.html">Focus Group</a></li>
 
 

--- a/docs/courses.html
+++ b/docs/courses.html
@@ -202,7 +202,7 @@ body{
               <li><a href="tutorials.html">Tutorials</a></li>
               <li><a href="Special.html">Special Issues</a></li>
               <li><a href="Atiisc.html">At AIISC</a></li>
-             <li><a href="https://aiisc.ai/safari/" target="_blank">AI Safari</a></li>
+             <li><a href="./aicamp24/base.html" target="_blank">AI Summer Camp</a></li>
 
 
             </ul>

--- a/docs/discussion.html
+++ b/docs/discussion.html
@@ -149,7 +149,7 @@ body{
               <li><a href="tutorials.html">Tutorials</a></li>
               <li><a href="Special.html">Special Issues</a></li>
               <li><a href="Atiisc.html" >At AIISC</a></li>
-             <li><a href="https://aiisc.ai/safari/" target="_blank">AI Safari</a></li>
+             <li><a href="./aicamp24/base.html" target="_blank">AI Summer Camp</a></li>
               
 
               <li><a href="focus.html">Focus Group</a></li>

--- a/docs/dissertation.html
+++ b/docs/dissertation.html
@@ -196,7 +196,7 @@ body{
               <li><a href="tutorials.html">Tutorials</a></li>
               <li><a href="Special.html">Special Issues</a></li>
               <li><a href="Atiisc.html"  >At AIISC</a></li>
-             <li><a href="https://aiisc.ai/safari/" target="_blank">AI Safari</a></li>
+             <li><a href="./aicamp24/base.html" target="_blank">AI Summer Camp</a></li>
               <li><a href="focus.html">Focus Group</a></li>
 
 

--- a/docs/facility.html
+++ b/docs/facility.html
@@ -199,7 +199,7 @@ body{
               <li><a href="workshop.html">Workshops</a></li>
               <li><a href="tutorials.html">Tutorials</a></li><li><a href="Special.html">Special Issues</a></li>
               <li><a href="Atiisc.html" >At AIISC</a></li>
-             <li><a href="https://aiisc.ai/safari/" target="_blank">AI Safari</a></li>
+             <li><a href="./aicamp24/base.html" target="_blank">AI Summer Camp</a></li>
               <li><a href="focus.html">Focus Group</a></li>
 
 

--- a/docs/focus.html
+++ b/docs/focus.html
@@ -155,7 +155,7 @@
               <li><a href="tutorials.html">Tutorials</a></li>
               <li><a href="Special.html">Special Issues</a></li>
               <li><a href="Atiisc.html">At AIISC</a></li>
-             <li><a href="https://aiisc.ai/safari/" target="_blank">AI Safari</a></li>
+             <li><a href="./aicamp24/base.html" target="_blank">AI Summer Camp</a></li>
               <li><a href="focus.html" class="active">Focus Group</a></li>
 
   

--- a/docs/index.html
+++ b/docs/index.html
@@ -100,7 +100,7 @@ body{
               <li><a href="workshop.html">Workshops</a></li>
               <li><a href="tutorials.html">Tutorials</a></li><li><a href="Special.html">Special Issues</a></li>
               <li><a href="Atiisc.html" >At AIISC</a></li>
-             <li><a href="https://aiisc.ai/safari/" target="_blank">AI Safari</a></li>
+             <li><a href="./aicamp24/base.html" target="_blank">AI Summer Camp</a></li>
               <li><a href="focus.html">Focus Group</a></li>
 
 

--- a/docs/opensource/index.html
+++ b/docs/opensource/index.html
@@ -218,7 +218,7 @@
               <li><a href="../workshop.html">Workshops</a></li>
               <li><a href="../tutorials.html">Tutorials</a></li><li><a href="../Special.html">Special Issues</a></li>
               <li><a href="../Atiisc.html" >At AIISC</a></li>
-             <li><a href="https://aiisc.ai/safari/" target="_blank">AI Safari</a></li>
+             <li><a href="../aicamp24/base.html" target="_blank">AI Summer Camp</a></li>
               <li><a href="../focus.html">Focus Group</a></li>
 
 

--- a/docs/overviewFall.html
+++ b/docs/overviewFall.html
@@ -171,7 +171,7 @@ body{
               <li><a href="tutorials.html">Tutorials</a></li>
               <li><a href="Special.html">Special Issues</a></li>
               <li><a href="Atiisc.html" >At AIISC</a></li>
-             <li><a href="https://aiisc.ai/safari/" target="_blank">AI Safari</a></li>
+             <li><a href="./aicamp24/base.html" target="_blank">AI Summer Camp</a></li>
               <li><a href="focus.html">Focus Group</a></li>
 
 

--- a/docs/people.html
+++ b/docs/people.html
@@ -185,7 +185,7 @@ body{
               <li><a href="tutorials.html">Tutorials</a></li>
               <li><a href="Special.html">Special Issues</a></li>
               <li><a href="Atiisc.html" >At AIISC</a></li>
-             <li><a href="https://aiisc.ai/safari/" target="_blank">AI Safari</a></li>
+             <li><a href="./aicamp24/base.html" target="_blank">AI Summer Camp</a></li>
               <li><a href="focus.html">Focus Group</a></li>
 
 

--- a/docs/projects.html
+++ b/docs/projects.html
@@ -184,7 +184,7 @@ body{
               <li><a href="tutorials.html">Tutorials</a></li>
               <li><a href="Special.html">Special Issues</a></li>
               <li><a href="Atiisc.html" >At AIISC</a></li>
-             <li><a href="https://aiisc.ai/safari/" target="_blank">AI Safari</a></li>
+             <li><a href="./aicamp24/base.html" target="_blank">AI Summer Camp</a></li>
               <li><a href="focus.html">Focus Group</a></li>
 
 

--- a/docs/reach.html
+++ b/docs/reach.html
@@ -156,7 +156,7 @@ body{
               <li><a href="tutorials.html">Tutorials</a></li>
               <li><a href="Special.html">Special Issues</a></li>
               <li><a href="Atiisc.html">At AIISC</a></li>
-             <li><a href="https://aiisc.ai/safari/" target="_blank">AI Safari</a></li>
+             <li><a href="./aicamp24/base.html" target="_blank">AI Summer Camp</a></li>
               <li><a href="focus.html">Focus Group</a></li>
 
   

--- a/docs/research.html
+++ b/docs/research.html
@@ -173,7 +173,7 @@ body{
               <li><a href="tutorials.html">Tutorials</a></li>
               <li><a href="Special.html">Special Issues</a></li>
               <li><a href="Atiisc.html">At AIISC</a></li>
-             <li><a href="https://aiisc.ai/safari/" target="_blank">AI Safari</a></li>
+             <li><a href="./aicamp24/base.html" target="_blank">AI Summer Camp</a></li>
               <li><a href="focus.html">Focus Group</a></li>
 
 

--- a/docs/showcase.html
+++ b/docs/showcase.html
@@ -214,7 +214,7 @@
               <li><a href="tutorials.html">Tutorials</a></li>
               <li><a href="Special.html">Special Issues</a></li>
               <li><a href="Atiisc.html">At AIISC</a></li>
-             <li><a href="https://aiisc.ai/safari/" target="_blank">AI Safari</a></li>
+             <li><a href="./aicamp24/base.html" target="_blank">AI Summer Camp</a></li>
               <li><a href="focus.html">Focus Group</a></li>
 
 

--- a/docs/tutorials.html
+++ b/docs/tutorials.html
@@ -179,7 +179,7 @@ body{
               <li><a href="tutorials.html" class="active">Tutorials</a></li>
               <li><a href="Special.html">Special Issues</a></li>
               <li><a href="Atiisc.html">At AIISC</a></li>
-             <li><a href="https://aiisc.ai/safari/" target="_blank">AI Safari</a></li>
+             <li><a href="./aicamp24/base.html" target="_blank">AI Summer Camp</a></li>
               <li><a href="focus.html">Focus Group</a></li>
 
 

--- a/docs/vision.html
+++ b/docs/vision.html
@@ -151,7 +151,7 @@ body{
               <li><a href="tutorials.html">Tutorials</a></li>
               <li><a href="Special.html">Special Issues</a></li>
               <li><a href="Atiisc.html" >At AIISC</a></li>
-             <li><a href="https://aiisc.ai/safari/" target="_blank">AI Safari</a></li>
+             <li><a href="./aicamp24/base.html" target="_blank">AI Safari</a></li>
               <li><a href="focus.html">Focus Group</a></li>
 
 

--- a/docs/vision.html
+++ b/docs/vision.html
@@ -151,7 +151,7 @@ body{
               <li><a href="tutorials.html">Tutorials</a></li>
               <li><a href="Special.html">Special Issues</a></li>
               <li><a href="Atiisc.html" >At AIISC</a></li>
-             <li><a href="./aicamp24/base.html" target="_blank">AI Safari</a></li>
+             <li><a href="./aicamp24/base.html" target="_blank">AI Summer Camp</a></li>
               <li><a href="focus.html">Focus Group</a></li>
 
 

--- a/docs/workshop.html
+++ b/docs/workshop.html
@@ -103,7 +103,7 @@
               <li><a href="tutorials.html">Tutorials</a></li>
               <li><a href="Special.html">Special Issues</a></li>
               <li><a href="Atiisc.html" >At AIISC</a></li>
-             <li><a href="https://aiisc.ai/safari/" target="_blank">AI Safari</a></li>
+             <li><a href="./aicamp24/base.html" target="_blank">AI Summer Camp</a></li>
               
 
               <li><a href="focus.html">Focus Group</a></li>


### PR DESCRIPTION
Included correct href in all <a> tags to point to AI Summer Camp instead of AI Safari/2023 Summer Camp Website